### PR TITLE
Add seed flag

### DIFF
--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -685,7 +685,9 @@ public class KeycardApplet extends Applet {
         loadKeyPair(apduBuffer);
         break;
       case LOAD_KEY_P1_SEED:
+        // If you load a seed this way, it will NOT be exportable
         loadSeed(apduBuffer);
+        masterSeedFlag = SFLAG_NONE;
         break;
       default:
         ISOException.throwIt(ISO7816.SW_INCORRECT_P1P2);

--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -700,10 +700,9 @@ public class KeycardApplet extends Applet {
   private void setSeedFlag(byte flag) {
     JCSystem.beginTransaction();
     if (flag > SFLAG_MAX || flag < 0) {
-      masterSeedFlag = SFLAG_NONE;
-    } else {
-      masterSeedFlag = flag;
+      ISOException.throwIt(ISO7816.SW_DATA_INVALID);
     }
+    masterSeedFlag = flag;
     JCSystem.commitTransaction();
     return;
   }


### PR DESCRIPTION
Adds a flag to the `masterSeed` when it is generated or imported.

- [x] Add flag option to `loadKey` (using p1 and p2)

- [x] Add flag option to `generateKey` (using p1)

- [x] Test all pubkeys are correct and all flags