### PR TITLE
ReInit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
   dependencies {
     classpath 'com.fidesmo:gradle-javacard:0.2.7'
     classpath 'org.junit.platform:junit-platform-gradle-plugin:1.1.1'
-    classpath 'com.github.gridplus.safe-card-java-sdk:desktop:a22fb496e0961f32fdcf3d2f1401470c1c083a7d'
+    classpath 'com.github.gridplus.safe-card-java-sdk:desktop:d8df11359a461e06f890e58446d2dcc24efe47b6'
     // classpath 'com.github.status-im.status-keycard-java:desktop:5771994'
   }
 }

--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -116,6 +116,9 @@ public class KeycardApplet extends Applet {
   static final byte SFLAG_EXPORTABLE = 1;
   static final byte SFLAG_MAX = 1;
 
+  static final byte INIT_P1_FIRST = 0x00;
+  static final byte INIT_P1_NEW = 0x01;
+
   private OwnerPIN pin;
   private OwnerPIN puk;
   private byte[] uid;
@@ -249,6 +252,7 @@ public class KeycardApplet extends Applet {
   public void process(APDU apdu) throws ISOException {
     byte[] apduBuffer = apdu.getBuffer();
     byte code = apduBuffer[ISO7816.OFFSET_INS];
+    byte p1 = apduBuffer[ISO7816.OFFSET_P1];
     
     // Cert loading should happen before init
     if (code == INS_LOAD_CERTS) {
@@ -264,7 +268,7 @@ public class KeycardApplet extends Applet {
     }
 
     // If we have no PIN it means we still have to initialize the applet.
-    if (pin == null) {
+    if (pin == null || (code == INS_INIT && p1 == INIT_P1_NEW)) {
       processInit(apdu);
       return;
     }
@@ -375,7 +379,8 @@ public class KeycardApplet extends Applet {
   private void processInit(APDU apdu) {
     byte[] apduBuffer = apdu.getBuffer();
     apdu.setIncomingAndReceive();
-
+    byte cmd = apduBuffer[ISO7816.OFFSET_INS];
+    byte p1 = apduBuffer[ISO7816.OFFSET_P1];
     if (selectingApplet()) {
       short off = 0;
 
@@ -397,7 +402,8 @@ public class KeycardApplet extends Applet {
       // Send the APDU buffer
       apdu.setOutgoingAndSend((short) 0, (short) off);
 
-    } else if (apduBuffer[ISO7816.OFFSET_INS] == INS_INIT) {
+    } else if (cmd == INS_INIT && p1 == INIT_P1_FIRST) {
+      // The first time we are calling INIT - load the PIN and PUK
       secureChannel.oneShotDecrypt(apduBuffer);
 
       if ((apduBuffer[ISO7816.OFFSET_LC] != (byte)(PIN_LENGTH + PUK_LENGTH + SecureChannel.SC_SECRET_LENGTH)) || !allDigits(apduBuffer, ISO7816.OFFSET_CDATA, (short)(PIN_LENGTH + PUK_LENGTH))) {
@@ -414,6 +420,18 @@ public class KeycardApplet extends Applet {
       puk.update(apduBuffer, (short)(ISO7816.OFFSET_CDATA + PIN_LENGTH), PUK_LENGTH);
 
       JCSystem.commitTransaction();
+    } else if (cmd == INS_INIT && p1 == INIT_P1_NEW) {
+      // The card has already been initialized, but we need to create a pairing
+      secureChannel.oneShotDecrypt(apduBuffer);
+
+      if (apduBuffer[ISO7816.OFFSET_LC] != (byte)(SecureChannel.SC_SECRET_LENGTH)) {
+        ISOException.throwIt(ISO7816.SW_WRONG_DATA);
+      }
+
+      JCSystem.beginTransaction();
+      secureChannel.reInitSecureChannel(apduBuffer, (short)(ISO7816.OFFSET_CDATA));
+      JCSystem.commitTransaction();
+      
     } else {
       ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
     }

--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -428,6 +428,10 @@ public class KeycardApplet extends Applet {
         ISOException.throwIt(ISO7816.SW_WRONG_DATA);
       }
 
+      if (secureChannel.isInitialized == false) {
+        ISOException.throwIt(ISO7816.SW_COMMAND_NOT_ALLOWED);
+      }
+
       JCSystem.beginTransaction();
       secureChannel.reInitSecureChannel(apduBuffer, (short)(ISO7816.OFFSET_CDATA));
       JCSystem.commitTransaction();

--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -116,8 +116,8 @@ public class KeycardApplet extends Applet {
   static final byte SFLAG_EXPORTABLE = 1;
   static final byte SFLAG_MAX = 1;
 
-  static final byte INIT_P1_FIRST = 0x00;
-  static final byte INIT_P1_NEW = 0x01;
+  static final byte INIT_P1_FIRST_TIME = 0x00;
+  static final byte INIT_P1_NEW_CLIENT = 0x01;
 
   private OwnerPIN pin;
   private OwnerPIN puk;
@@ -268,7 +268,7 @@ public class KeycardApplet extends Applet {
     }
 
     // If we have no PIN it means we still have to initialize the applet.
-    if (pin == null || (code == INS_INIT && p1 == INIT_P1_NEW)) {
+    if (pin == null || (code == INS_INIT && p1 == INIT_P1_NEW_CLIENT)) {
       processInit(apdu);
       return;
     }
@@ -402,7 +402,7 @@ public class KeycardApplet extends Applet {
       // Send the APDU buffer
       apdu.setOutgoingAndSend((short) 0, (short) off);
 
-    } else if (cmd == INS_INIT && p1 == INIT_P1_FIRST) {
+    } else if (cmd == INS_INIT && p1 == INIT_P1_FIRST_TIME) {
       // The first time we are calling INIT - load the PIN and PUK
       secureChannel.oneShotDecrypt(apduBuffer);
 
@@ -420,7 +420,7 @@ public class KeycardApplet extends Applet {
       puk.update(apduBuffer, (short)(ISO7816.OFFSET_CDATA + PIN_LENGTH), PUK_LENGTH);
 
       JCSystem.commitTransaction();
-    } else if (cmd == INS_INIT && p1 == INIT_P1_NEW) {
+    } else if (cmd == INS_INIT && p1 == INIT_P1_NEW_CLIENT) {
       // The card has already been initialized, but we need to create a pairing
       secureChannel.oneShotDecrypt(apduBuffer);
 

--- a/src/main/java/im/status/keycard/SecureChannel.java
+++ b/src/main/java/im/status/keycard/SecureChannel.java
@@ -35,6 +35,8 @@ public class SecureChannel {
 
   private short scCounter;
 
+  public boolean isInitialized = false;
+
   /*
    * To avoid overhead, the pairing keys are stored in a plain byte array as sequences of 33-bytes elements. The first
    * byte is 0 if the slot is free and 1 if used. The following 32 bytes are the actual key data.
@@ -82,6 +84,7 @@ public class SecureChannel {
     pairingSecret = new byte[SC_SECRET_LENGTH];
     Util.arrayCopy(aPairingSecret, off, pairingSecret, (short) 0, SC_SECRET_LENGTH);
     scKeypair.genKeyPair();
+    isInitialized = true;
   }
 
 
@@ -94,6 +97,8 @@ public class SecureChannel {
    * @param off the offset in the buffer
    */
   public void reInitSecureChannel(byte[] aPairingSecret, short off) {
+    if (isInitialized == false) return;
+    
     pairingSecret = new byte[SC_SECRET_LENGTH];
     Util.arrayCopy(aPairingSecret, off, pairingSecret, (short) 0, SC_SECRET_LENGTH);
   }

--- a/src/main/java/im/status/keycard/SecureChannel.java
+++ b/src/main/java/im/status/keycard/SecureChannel.java
@@ -84,6 +84,21 @@ public class SecureChannel {
     scKeypair.genKeyPair();
   }
 
+
+  /**
+   * Re-initializes the SecureChannel instance with the pairing secret.
+   * This allows the client to create a pairing with a card that has already been
+   * initialized. The PIN and PUK cannot be changed.
+   *
+   * @param aPairingSecret the pairing secret
+   * @param off the offset in the buffer
+   */
+  public void reInitSecureChannel(byte[] aPairingSecret, short off) {
+    pairingSecret = new byte[SC_SECRET_LENGTH];
+    Util.arrayCopy(aPairingSecret, off, pairingSecret, (short) 0, SC_SECRET_LENGTH);
+  }
+
+
   /**
    * Decrypts the content of the APDU by generating an AES key using EC-DH. Usable only with specific commands.
    * @param apduBuffer the APDU buffer

--- a/src/test/java/im/status/keycard/KeycardTest.java
+++ b/src/test/java/im/status/keycard/KeycardTest.java
@@ -1765,6 +1765,38 @@ public class KeycardTest {
     }
   }
 
+  @Test
+  @DisplayName("ReInit")
+  void reInitTest() throws Exception {
+    APDUResponse response;
+    Random random = new Random();
+    byte[] pairingSecret = new byte[32];
+    byte[] challenge = new byte[32];
+    byte[] pairingPass = new byte[16];
+    String pairingPassword;
+    random.nextBytes(pairingSecret);
+    assertEquals(0x6D00, cmdSet.init("000000", "123456789012", pairingSecret).getSw());
+    initCapabilities(cmdSet.getApplicationInfo());
+
+    for (int i = 0; i < 5; i++) {
+      random.nextBytes(pairingPass);
+      pairingPassword = new String(pairingPass);
+      // Generate the pairing secret
+      pairingSecret = cmdSet.pairingPasswordToSecret(System.getProperty("im.status.keycard.test.pairing", pairingPassword));
+      // Encrypt the secret using an ECDH shared secret derived from a random keypair
+      byte[] enc = secureChannel.oneShotEncrypt(pairingSecret);
+      // Start the initialization process again to store the new pairingSecret
+      response = sdkChannel.send(new APDUCommand(0x80, KeycardApplet.INS_INIT, KeycardApplet.INIT_P1_NEW, (byte) 0, enc));
+      assertEquals(0x9000, response.getSw());
+      // Pair with this new pairing secret and open a secure channel
+      cmdSet.autoPair(pairingSecret);
+      response = cmdSet.openSecureChannel(secureChannel.getPairingIndex(), secureChannel.getPublicKey());
+      assertEquals(0x9000, response.getSw());
+      // Fair again to init the normal way
+      assertEquals(0x6D00, cmdSet.init("000000", "123456789012", pairingSecret).getSw()); 
+    }
+  }
+
   //====================================
   // END GRIDPLUS SAFECARD TESTS
   //====================================

--- a/src/test/java/im/status/keycard/KeycardTest.java
+++ b/src/test/java/im/status/keycard/KeycardTest.java
@@ -1793,7 +1793,7 @@ public class KeycardTest {
       response = cmdSet.openSecureChannel(secureChannel.getPairingIndex(), secureChannel.getPublicKey());
       assertEquals(0x9000, response.getSw());
       // Fair again to init the normal way
-      assertEquals(0x6D00, cmdSet.init("000000", "123456789012", pairingSecret).getSw()); 
+      assertEquals(0x6D00, cmdSet.init("000000", "123456789012", pairingSecret).getSw());
     }
   }
 

--- a/src/test/java/im/status/keycard/KeycardTest.java
+++ b/src/test/java/im/status/keycard/KeycardTest.java
@@ -1786,7 +1786,7 @@ public class KeycardTest {
       // Encrypt the secret using an ECDH shared secret derived from a random keypair
       byte[] enc = secureChannel.oneShotEncrypt(pairingSecret);
       // Start the initialization process again to store the new pairingSecret
-      response = sdkChannel.send(new APDUCommand(0x80, KeycardApplet.INS_INIT, KeycardApplet.INIT_P1_NEW, (byte) 0, enc));
+      response = sdkChannel.send(new APDUCommand(0x80, KeycardApplet.INS_INIT, KeycardApplet.INIT_P1_NEW_CLIENT, (byte) 0, enc));
       assertEquals(0x9000, response.getSw());
       // Pair with this new pairing secret and open a secure channel
       cmdSet.autoPair(pairingSecret);


### PR DESCRIPTION
The current Keycard applet only allows `INIT` to be called once. This prevents the card from pairing and communicating with multiple devices, as the init process is what allows the client to put its pairing secret onto the card.

This PR adds the option to "re-init" by calling `INIT` with `p1=0x01`. This overwrites the pairing secret without affecting any of the other init functionality. With the new pairing secret, the new device may pair and start communicating.

> Recall that pairings now overwrite a single slot, so all devices must now use this re-init functionality, even the original device (if the card has since paired with another device)