### PR TITLE
Removes stateful `isInitialized` boolean

### DIFF
--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -428,7 +428,8 @@ public class KeycardApplet extends Applet {
         ISOException.throwIt(ISO7816.SW_WRONG_DATA);
       }
 
-      if (secureChannel.isInitialized == false) {
+      if (pin == null) {
+        // Don't allow re-init if init hasn't happened
         ISOException.throwIt(ISO7816.SW_COMMAND_NOT_ALLOWED);
       }
 

--- a/src/main/java/im/status/keycard/SecureChannel.java
+++ b/src/main/java/im/status/keycard/SecureChannel.java
@@ -35,8 +35,6 @@ public class SecureChannel {
 
   private short scCounter;
 
-  public boolean isInitialized = false;
-
   /*
    * To avoid overhead, the pairing keys are stored in a plain byte array as sequences of 33-bytes elements. The first
    * byte is 0 if the slot is free and 1 if used. The following 32 bytes are the actual key data.
@@ -84,7 +82,6 @@ public class SecureChannel {
     pairingSecret = new byte[SC_SECRET_LENGTH];
     Util.arrayCopy(aPairingSecret, off, pairingSecret, (short) 0, SC_SECRET_LENGTH);
     scKeypair.genKeyPair();
-    isInitialized = true;
   }
 
 
@@ -97,7 +94,7 @@ public class SecureChannel {
    * @param off the offset in the buffer
    */
   public void reInitSecureChannel(byte[] aPairingSecret, short off) {
-    if (isInitialized == false) return;
+    if (pairingSecret == null) return;
     
     pairingSecret = new byte[SC_SECRET_LENGTH];
     Util.arrayCopy(aPairingSecret, off, pairingSecret, (short) 0, SC_SECRET_LENGTH);


### PR DESCRIPTION
As pointed out in #14, we don't need the additional state variable to prevent `re-init` from being called before `init` is first called. We can use existing variables.