### PR TITLE
Card Authentication

### DIFF
--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -207,14 +207,17 @@ public class KeycardApplet extends Applet {
     certs = new byte[CERTS_LEN];
     certsLoaded = 0;
     certsLoadedLen = (byte) 0;
-    certsAuthPublic = (ECPublicKey) KeyBuilder.buildKey(KeyBuilder.TYPE_EC_FP_PUBLIC, SECP256k1.SECP256K1_KEY_SIZE, false);
-    certsAuthPrivate = (ECPrivateKey) KeyBuilder.buildKey(KeyBuilder.TYPE_EC_FP_PRIVATE, SECP256k1.SECP256K1_KEY_SIZE, false);
-    byte[] privBuf = new byte[Crypto.KEY_SECRET_SIZE];
-    crypto.random.generateData(privBuf, (short) 0, Crypto.KEY_SECRET_SIZE);
-    certsAuthPrivate.setS(privBuf, (short) 0, Crypto.KEY_SECRET_SIZE);
-    byte[] pubBuf = new byte[Crypto.KEY_PUB_SIZE];
-    secp256k1.derivePublicKey(privBuf, (short) 0, pubBuf, (short) 0);
-    certsAuthPublic.setW(pubBuf, (short) 0, Crypto.KEY_PUB_SIZE);
+    // certsAuthPublic = (ECPublicKey) KeyBuilder.buildKey(KeyBuilder.TYPE_EC_FP_PUBLIC, SECP256k1.SECP256K1_KEY_SIZE, false);
+    // certsAuthPrivate = (ECPrivateKey) KeyBuilder.buildKey(KeyBuilder.TYPE_EC_FP_PRIVATE, SECP256k1.SECP256K1_KEY_SIZE, false);
+    // secp256k1.setCurveParameters(certsAuthPublic);
+    // secp256k1.setCurveParameters(certsAuthPrivate);
+    // byte[] privBuf = new byte[Crypto.KEY_SECRET_SIZE];
+    // crypto.random.generateData(privBuf, (short) 0, Crypto.KEY_SECRET_SIZE);
+    // certsAuthPrivate.setS(privBuf, (short) 0, Crypto.KEY_SECRET_SIZE);
+
+    // byte[] pubBuf = new byte[Crypto.KEY_PUB_SIZE];
+    // secp256k1.derivePublicKey(privBuf, (short) 0, pubBuf, (short) 0);
+    // certsAuthPublic.setW(pubBuf, (short) 0, Crypto.KEY_PUB_SIZE);
 
     masterSeed = new byte[BIP39_SEED_SIZE];
     masterSeedFlag = SFLAG_NONE;
@@ -876,6 +879,7 @@ public class KeycardApplet extends Applet {
   }
 
   private void authenticate(APDU apdu) {
+    Signature tmpSig = Signature.getInstance(Signature.ALG_ECDSA_SHA_256, false);
     byte[] apduBuffer = apdu.getBuffer();
     apdu.setIncomingAndReceive();
     byte[] msgHash = new byte[Crypto.KEY_SECRET_SIZE];
@@ -888,21 +892,29 @@ public class KeycardApplet extends Applet {
     // Add public key for verification
     apduBuffer[3] = TLV_PUB_KEY;
     short outLen = apduBuffer[4] = Crypto.KEY_PUB_SIZE;
-    certsAuthPublic.getW(apduBuffer, (short) 5);
+    // certsAuthPublic.getW(apduBuffer, (short) 5);
+    // certsAuthPrivate.getS(apduBuffer, (short) 5);
     outLen += 5;
     // Add signature of msg hash
     short sigOff = outLen;
-    signature.init(certsAuthPrivate, Signature.MODE_SIGN);
-    // signature.init(privateKey, Signature.MODE_SIGN);
 
-    /*
-    outLen += signature.signPreComputedHash(msgHash, (short) 0, MessageDigest.LENGTH_SHA_256, apduBuffer, sigOff);
-    outLen += crypto.fixS(apduBuffer, sigOff);
+/*
+FOR SOME REASON, USING privKey IS FINE BUT I CANT GET IT TO WORK WITH certsAuthPrivate
+NEED TO FIGURE OUT WHAT MAKES THESE KEYS DIFFERENT.
+I CANT EVEN GET signature.init TO WORK HERE (EVEN WITH tmpSig, WHICH WE SHOULDNT HAVE TO USE)
+*/
+
+    // ECPrivateKey signingKey = certsAuthPrivate;
+    // tmpSig.init(masterPrivate, Signature.MODE_SIGN);
+    // tmpSig.init(signingKey, Signature.MODE_VERIFY);
+    
+    // outLen += signature.signPreComputedHash(msgHash, (short) 0, MessageDigest.LENGTH_SHA_256, apduBuffer, sigOff);
+    // outLen += crypto.fixS(apduBuffer, sigOff);
 
     // Finally add the full payload length to the front
-    apduBuffer[2] = (byte) (outLen - 3);
-*/
-    apdu.setOutgoingAndSend((short) 0, (short) outLen);
+    // apduBuffer[2] = (byte) (outLen - 3);
+
+    apdu.setOutgoingAndSend((short) 0, (short) 3);
   }
 
   /**

--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -878,7 +878,7 @@ public class KeycardApplet extends Applet {
     byte[] apduBuffer = apdu.getBuffer();
     short off = 0;
     apduBuffer[off++] = TLV_CERTS;
-    apduBuffer[off++] = (byte) (CERT_LEN * numCertsLoaded);
+    apduBuffer[off++] = (byte) ((2 + CERT_LEN) * numCertsLoaded); // Each cert has a 2-byte header
     for (short i = 0; i < numCertsLoaded; i++) {
       apduBuffer[off++] = TLV_CERT;
       apduBuffer[off++] = CERT_LEN;

--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -899,25 +899,18 @@ public class KeycardApplet extends Applet {
     short outLen = apduBuffer[4] = Crypto.KEY_PUB_SIZE;
     certsAuthPublic.getW(apduBuffer, (short) 5);
     outLen += 5;
-
-    // Add signature of msg hash
+    
     short sigOff = outLen;
 
-/*
-FOR SOME REASON, USING privKey IS FINE BUT I CANT GET IT TO WORK WITH certsAuthPrivate
-NEED TO FIGURE OUT WHAT MAKES THESE KEYS DIFFERENT.
-I CANT EVEN GET signature.init TO WORK HERE (EVEN WITH tmpSig, WHICH WE SHOULDNT HAVE TO USE)
-*/
-
+    // Add signature of msg hash
     tmpSig.init(certsAuthPrivate, Signature.MODE_SIGN);
-    
     outLen += tmpSig.signPreComputedHash(msgHash, (short) 0, MessageDigest.LENGTH_SHA_256, apduBuffer, sigOff);
     outLen += crypto.fixS(apduBuffer, sigOff);
 
-    // Finally add the full payload length to the front
+    // // Finally add the full payload length to the front
     apduBuffer[2] = (byte) (outLen - 3);
 
-    apdu.setOutgoingAndSend((short) 0, (short) outLen);
+    apdu.setOutgoingAndSend((short) 0, (short) outLen);    
   }
 
   /**

--- a/src/test/java/im/status/keycard/KeycardTest.java
+++ b/src/test/java/im/status/keycard/KeycardTest.java
@@ -1530,6 +1530,36 @@ public class KeycardTest {
   //====================================
 
   @Test
+  @DisplayName("Authentication")
+  void authTest() throws Exception {
+    // Build msg hash and setup
+    Random random = new Random();
+    byte[] msg = new byte[32];
+    random.nextBytes(msg);
+    APDUResponse response;
+
+    // Get public key for verification
+    byte[] data = cmdSet.select().checkOK().getData();
+    int pubKeyIdx = 0;
+    for(int i = 0; i < data.length; i++) {
+      if (data[i] == KeycardApplet.TLV_PUB_KEY) {
+        // The identifying pubkey we want is the latter (of 2) pubkeys
+        // returned from an applet select
+        pubKeyIdx = i;
+      }
+    }
+    System.out.println(pubKeyIdx);
+
+    // Request signature on msg hash
+    response = cmdSet.sendCommand(KeycardApplet.INS_AUTHENTICATE, (byte) 0, (byte) 0, msg);
+    assertEquals(0x9000, response.getSw());
+    byte[] sig = response.getData();
+
+    // Verify signature matches msg hash and public key
+    System.out.println(Arrays.toString(sig));
+  }
+
+  @Test
   @DisplayName("Certs")
   void loadCertsTest() throws Exception {
     int len = KeycardApplet.CERTS_LEN - 5;

--- a/src/test/java/im/status/keycard/KeycardTest.java
+++ b/src/test/java/im/status/keycard/KeycardTest.java
@@ -1580,7 +1580,7 @@ public class KeycardTest {
     assertEquals(0x9000, response.getSw());
     byte[] exportedCerts = response.getData();
     assertEquals(exportedCerts[0] & 0xff, KeycardApplet.TLV_CERTS & 0xff);
-    assertEquals(exportedCerts[1] & 0xff, len & 0xff);
+    assertEquals(exportedCerts[1] & 0xff, (len + (2 * numCerts)) & 0xff);
 
     // Look at first cert
     assertEquals(exportedCerts[2] & 0xff, KeycardApplet.TLV_CERT & 0xff);

--- a/src/test/java/im/status/keycard/KeycardTest.java
+++ b/src/test/java/im/status/keycard/KeycardTest.java
@@ -1537,26 +1537,34 @@ public class KeycardTest {
     byte[] msg = new byte[32];
     random.nextBytes(msg);
     APDUResponse response;
+    Signature signature = Signature.getInstance("SHA256withECDSA", "BC");
+    ECParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("secp256k1");
 
-    // Get public key for verification
-    byte[] data = cmdSet.select().checkOK().getData();
-    int pubKeyIdx = 0;
-    for(int i = 0; i < data.length; i++) {
-      if (data[i] == KeycardApplet.TLV_PUB_KEY) {
-        // The identifying pubkey we want is the latter (of 2) pubkeys
-        // returned from an applet select
-        pubKeyIdx = i;
-      }
-    }
-    System.out.println(pubKeyIdx);
-
-    // Request signature on msg hash
+    // Get public key and signature
     response = cmdSet.sendCommand(KeycardApplet.INS_AUTHENTICATE, (byte) 0, (byte) 0, msg);
     assertEquals(0x9000, response.getSw());
-    byte[] sig = response.getData();
+    byte[] data = response.getData();
+    System.out.println("data");
+    System.out.println(data);
+
+    // The authentication pubkey should be the last 65 bytes of the data
+    // int pubKeyIdx = data.length - Crypto.KEY_PUB_SIZE;
+    // byte[] pubKeyBytes = Arrays.copyOfRange(data, pubKeyIdx, pubKeyIdx + Crypto.KEY_PUB_SIZE);
+    // System.out.println("pubKeyBytes");
+    // System.out.println(Arrays.toString(pubKeyBytes));
+    // ECPublicKeySpec pubKeySpec = new ECPublicKeySpec(ecSpec.getCurve().decodePoint(pubKeyBytes), ecSpec);
+    // ECPublicKey pubKey = (ECPublicKey) KeyFactory.getInstance("ECDSA", "BC").generatePublic(pubKeySpec);
+
+    // // Request signature on msg hash
+    // response = cmdSet.sendCommand(KeycardApplet.INS_AUTHENTICATE, (byte) 0, (byte) 0, msg);
+    // assertEquals(0x9000, response.getSw());
+    // byte[] sig = response.getData();
+    // signature.initVerify(pubKey);
+    // signature.update(new byte[8]);
+    // assertTrue(signature.verify(sig));
 
     // Verify signature matches msg hash and public key
-    System.out.println(Arrays.toString(sig));
+    // System.out.println(Arrays.toString(sig));
   }
 
   @Test

--- a/src/test/java/im/status/keycard/KeycardTest.java
+++ b/src/test/java/im/status/keycard/KeycardTest.java
@@ -233,6 +233,42 @@ public class KeycardTest {
   }
 
   @Test
+  @DisplayName("Authentication")
+  void authTest() throws Exception {
+    // Build msg hash and setup
+    Random random = new Random();
+    byte[] msg = new byte[32];
+    random.nextBytes(msg);
+    APDUResponse response;
+    
+    // Get public key and signature
+    response = cmdSet.sendCommand(KeycardApplet.INS_AUTHENTICATE, (byte) 0, (byte) 0, msg);
+    assertEquals(0x9000, response.getSw());
+    byte[] data = response.getData();
+    System.out.println("data");
+    System.out.println(Arrays.toString(data));
+
+    // The authentication pubkey should be the last 65 bytes of the data
+    // int pubKeyIdx = data.length - Crypto.KEY_PUB_SIZE;
+    // byte[] pubKeyBytes = Arrays.copyOfRange(data, pubKeyIdx, pubKeyIdx + Crypto.KEY_PUB_SIZE);
+    // System.out.println("pubKeyBytes");
+    // System.out.println(Arrays.toString(pubKeyBytes));
+    // ECPublicKeySpec pubKeySpec = new ECPublicKeySpec(ecSpec.getCurve().decodePoint(pubKeyBytes), ecSpec);
+    // ECPublicKey pubKey = (ECPublicKey) KeyFactory.getInstance("ECDSA", "BC").generatePublic(pubKeySpec);
+
+    // // Request signature on msg hash
+    // response = cmdSet.sendCommand(KeycardApplet.INS_AUTHENTICATE, (byte) 0, (byte) 0, msg);
+    // assertEquals(0x9000, response.getSw());
+    // byte[] sig = response.getData();
+    // signature.initVerify(pubKey);
+    // signature.update(new byte[8]);
+    // assertTrue(signature.verify(sig));
+
+    // Verify signature matches msg hash and public key
+    // System.out.println(Arrays.toString(sig));
+  }
+
+  @Test
   @DisplayName("OPEN SECURE CHANNEL command")
   @Capabilities("secureChannel")
   void openSecureChannelTest() throws Exception {
@@ -1528,44 +1564,6 @@ public class KeycardTest {
   //====================================
   // GRIDPLUS SAFECARD TESTS
   //====================================
-
-  @Test
-  @DisplayName("Authentication")
-  void authTest() throws Exception {
-    // Build msg hash and setup
-    Random random = new Random();
-    byte[] msg = new byte[32];
-    random.nextBytes(msg);
-    APDUResponse response;
-    Signature signature = Signature.getInstance("SHA256withECDSA", "BC");
-    ECParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("secp256k1");
-
-    // Get public key and signature
-    response = cmdSet.sendCommand(KeycardApplet.INS_AUTHENTICATE, (byte) 0, (byte) 0, msg);
-    assertEquals(0x9000, response.getSw());
-    byte[] data = response.getData();
-    System.out.println("data");
-    System.out.println(data);
-
-    // The authentication pubkey should be the last 65 bytes of the data
-    // int pubKeyIdx = data.length - Crypto.KEY_PUB_SIZE;
-    // byte[] pubKeyBytes = Arrays.copyOfRange(data, pubKeyIdx, pubKeyIdx + Crypto.KEY_PUB_SIZE);
-    // System.out.println("pubKeyBytes");
-    // System.out.println(Arrays.toString(pubKeyBytes));
-    // ECPublicKeySpec pubKeySpec = new ECPublicKeySpec(ecSpec.getCurve().decodePoint(pubKeyBytes), ecSpec);
-    // ECPublicKey pubKey = (ECPublicKey) KeyFactory.getInstance("ECDSA", "BC").generatePublic(pubKeySpec);
-
-    // // Request signature on msg hash
-    // response = cmdSet.sendCommand(KeycardApplet.INS_AUTHENTICATE, (byte) 0, (byte) 0, msg);
-    // assertEquals(0x9000, response.getSw());
-    // byte[] sig = response.getData();
-    // signature.initVerify(pubKey);
-    // signature.update(new byte[8]);
-    // assertTrue(signature.verify(sig));
-
-    // Verify signature matches msg hash and public key
-    // System.out.println(Arrays.toString(sig));
-  }
 
   @Test
   @DisplayName("Certs")


### PR DESCRIPTION
We need to have an interactive authentication method, which functions as follows:

1. Card applet is installed and `certsAuth` keypair is created from the card's entropy
2. Certificate authority requests signature on message hash using `certsAuth` key. Response returns both the signature and the public key (for verification)
3. Certificate authority signs `certsAuth` public key with one or more signatures (i.e. 1-3 CA keys sign)
4. Certificate authority loads certificates onto the card before shipping
5. When card is inserted (every time), user device may export certs and then call `authenticate()` on a random hash.
6. User device may now verify `authenticate()` signature and cross-reference with the data signed by the CA, which will be the same `certsAuth` public key

----

- [x] Add `authenticate()` function - return signature TLV template
- [x] Export certs with TLV encoding (separate multiple certs with tags)
- [x] Tests
- [x] Update docs