### PR TITLE
Remove UID from processInit()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ javacard {
       className = 'NDEFApplet'
     }
     
-    version = '0.2'
+    version = '0.4'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ javacard {
       className = 'NDEFApplet'
     }
     
-    version = '0.4'
+    version = '0.5'
   }
 }
 

--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -412,26 +412,9 @@ public class KeycardApplet extends Applet {
     byte cmd = apduBuffer[ISO7816.OFFSET_INS];
     byte p1 = apduBuffer[ISO7816.OFFSET_P1];
     if (selectingApplet()) {
-      short off = 0;
-
-      // Add the secure channel public key to the output info
       apduBuffer[0] = TLV_PUB_KEY;
       apduBuffer[1] = (byte) secureChannel.copyPublicKey(apduBuffer, (short) 2);
-      off += 2;
-      off += apduBuffer[1];
-
-      // Get the instance UID. This is a unique identifier for the installation and
-      // cannot be updated after the app is installed. It is used to make the certificates.
-      apduBuffer[off] = TLV_UID;
-      off += 1;
-      apduBuffer[off] = UID_LENGTH;
-      off += 1;
-      Util.arrayCopyNonAtomic(uid, (short) 0, apduBuffer, off, UID_LENGTH);
-      off += UID_LENGTH;
-
-      // Send the APDU buffer
-      apdu.setOutgoingAndSend((short) 0, (short) off);
-
+      apdu.setOutgoingAndSend((short) 0, (short)(apduBuffer[1] + 2));
     } else if (cmd == INS_INIT && p1 == INIT_P1_FIRST_TIME) {
       // The first time we are calling INIT - load the PIN and PUK
       secureChannel.oneShotDecrypt(apduBuffer);


### PR DESCRIPTION
This PR:

1. Removes the UID data field from `processInit()` under the condition that the card is not yet initialized. We originally added the UID field for certificates, but that is no longer necessary, as we now use the card's `idPublicKey` for certification

2. Updates storage and API to only store and export a single certificate. We don't need more than this and leaving multiple slots open grows complexity (we'll take the 128 storage bytes too)