### PR TITLE
Cleans up authenticate() to not create any new objects

### DIFF
--- a/src/test/java/im/status/keycard/KeycardTest.java
+++ b/src/test/java/im/status/keycard/KeycardTest.java
@@ -1563,7 +1563,6 @@ public class KeycardTest {
     response = cmdSet.sendCommand(KeycardApplet.INS_AUTHENTICATE, (byte) 0, (byte) 0, hash);
     assertEquals(0x9000, response.getSw());
     byte[] data = response.getData();
-
     byte[] keyData = extractPublicKeyFromSignature(data);
     byte[] sig = extractSignature(data);
 


### PR DESCRIPTION
Allocating memory to temporary buffers can lead to problems should memory run out. This PR removes the temporary variables in the `authenticate` route. This is the only APDU that adds temporary variables and is one of the few changes relative to Status' applet.