### PR TITLE
GridPlus certificate based pairing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,15 @@
+.project
+.vscode
+
 # IntelliJ IDEA project files
 .idea
 *.iml
+buildSrc/build
+bin
 
 # Gradle output
+buildSrc/build
 /.gradle
+buildSrc/.gradle
 /build
 /gradle.properties

--- a/README.md
+++ b/README.md
@@ -1,3 +1,138 @@
+# SafeCard
+
+## Building and Installing
+
+SafeCard binaries come in the form of `.cap` files, which can be created with:
+
+```
+rm -r build && ./gradlew clean && ./gradlew convertJavacard
+```
+
+This produces the following file:
+
+```
+./build/javacard/im/status/keycard/javacard/keycard.cap
+```
+
+which serves as the distribution.
+
+The following commands are used for installation and development:
+
+* `./gradlew install` - installs the applet
+* `./gradlew build` - builds, installs, and tests the applet
+
+## Features and Changes
+
+This repo contains the Javacard applet that runs on the GridPlus SafeCard. It is a fork of the [Status KeyCard](https://github.com/status-im/status-keycard), with only a few notable changes. They are documented below.
+
+### `SELECT`
+
+The `SELECT` command returns the same data as [Status' response](https://status.im/keycard_api/apdu_select.html) with one
+additional piece appended to the end of the response data:
+
+`Tag 0x9F = SeedFlag (1 byte)`
+
+The value will be one of the following:
+* Seed not initialized: `0`
+* Seed initialized but not exportable: `1`
+* Seed initialized and exportable: `2`
+
+### Certificates and Card Authentication
+
+GridPlus SafeCards are typically used with a secure interface (the Lattice1), which queries the card for its certificates. Each cert is an ECDSA signature on the card's "authentication" public key and is signed by a GridPlus certificate authority. There are between 1 and 3 certs stored on the card.
+
+> The GridPlus CA produces 64-byte signatures (concatenated `r` and `s` components - fixed at 32 bytes each)
+
+#### `Load Certs (APDU 0xFA)`
+
+This APDU allows the card issuer to load certs on a card that has not been initialized. The payload length must be a multiple of cert length (64 bytes). 
+
+* P1: None
+* P2: None
+* Data: `<certs>`
+* Returns: None
+
+#### `Export Certs (APDU 0xFB)`
+
+This APDU allows any card holder to export the loaded certs for inspection. It can be called at any point and does not require a secure channel.
+
+* P1: None
+* P2: None
+* Data: None
+* Returns: `[ TLV_CERTS (0x91), <len(payload)>, TLV_CERT (0x92), <len(cert0)>, <cert0>, ... TLV_CERT (0x92), <len(certN)>, <certN>]`
+
+> `cert` is a 64-byte signature (`r` concatenated with `s`)
+
+#### `Authenticate (APDU 0xEE)`
+
+This APDU allows the user to request a signature on a hash from the "auth" keypair. It returns the same signature TLV template as `SIGN`.
+
+> This APDU does not use a secure channel because authorization and verification of the card should happen before the user inputs a PIN
+
+* P1: None
+* P2: None
+* Date: 32-byte hash
+* return `[ TLV_SIGNATURE_TEMPLATE, 0x81, <len(payload)>, TLV_PUB_KEY, <len(pubKey)>, <pubKey>, 0x30, <len(sig)>, 0x02, <len(sig.r)>, <sig.r>, 0x02, <len(sig.s)>, <sig.s>]`
+
+> Note that this signature template is the same as what `SIGN` would produce. I'm not sure where some of the tag byte values come from.
+
+### Master Seed
+
+Status does not currently save the master seed and, as such, does not allow the user to export that seed for backup purposes. This is understandable, as Status cannot assume a secure interface. However, GridPlus can - the Lattice1 (and specifically a secure compute element inside) is the main interface for SafeCards.
+
+GridPlus has added an APDU (Export Seed) and modified two others (LoadKey/GenerateKey) to allow for storage and exporting of the card's wallet's master seed. Note that the user has full control over whether this should be exportable at all. Many users may want to restrict their seed to the card itself and never back it up. However, we felt it was important to allow an exportable option.
+
+#### `GenerateKey (APDU 0xD4)`
+
+Modified to allow generation and storage of master seed with exportable option.
+
+* P1: Exportable option (0 for non-exportable, 1 for exportable)
+* P2: None
+* Data: None
+* Returns: Key UID (not important for GridPlus)
+
+#### `LoadKey (APDU 0xD0)`
+
+Modified to allow storage of master seed with exportable option. 
+
+*The following options assume you are loading a master seed:*
+
+* P1: `0x03` (same as Status')
+* P2: Exportable option (0 for non-exportable, 1 for exportable)
+* Data: `<seed>`
+* Returns: None
+
+#### `Export Seed (APDU 0xC3)`
+
+This APDU allows the card holder to export the master seed if they designated it as "exportable" when they loaded/generated it.
+
+* P1: None
+* P2: None
+* Data: None
+* Returns: `[ TLV_SEED (0x90), BIP39_SEED_SIZE (0x40), <seed>]`
+
+> `seed` is a 64-byte master seed
+
+### Intermediate Public Keys
+
+GridPlus wishes to export intermediate public keys (e.g. `m/44'/60'/0'/`), which can be used to create fully derived (unhardened) public keys (e.g. `m/44'/60'/0'/0/0`) *outside of the card environment*. In order to do external child key derivations, we need to export the chaincode as well.
+
+> GridPlus has modified the applet to **not allow export of private keys**. This is for various reasons, including the fact that we do allow exporting of master seeds and we allow exporting of the chaincode, which can be used with intermediate private keys to fully derive all unhardened child private keys.
+
+#### `Export Key (APDU 0xC2)`
+
+We have modified Export Key to allow exporting of chaincode and disallow exporting of private keys.
+
+* P1: Same as Status
+* P2: `0x02` exports public key and chaincode. `0x00` is disallowed.
+* Data: Same as Status
+* Returns (for P2=`0x02`): `[ TLV_PUB_KEY (0x80), PubKeyLen (0x41), <pubkey>, TLV_CHAIN_CODE (0x82), ChainCodeLen (0x20), <chaincode> ]` 
+
+
+---
+
+**[ORIGINAL STATUS DOCS BELOW]**
+
 # What is Keycard?
 
 Keycard is a an implementation of a BIP-32 HD wallet running on Javacard 3.0.4+ (see implementation notes)

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
   dependencies {
     classpath 'com.fidesmo:gradle-javacard:0.2.7'
     classpath 'org.junit.platform:junit-platform-gradle-plugin:1.1.1'
-    classpath 'com.github.status-im.status-keycard-java:desktop:2.0.0'
+    classpath 'com.github.gridplus.safe-card-java-sdk:desktop:3ae2324b08c041be30886b9fc2e1b04c2573d750'
   }
 }
 
@@ -19,18 +19,18 @@ javacard {
   sdkVersion = "3.0.4"
 
   cap {
-    aid = '0xA0:0x00:0x00:0x08:0x04:0x00:0x01'
+    aid = '0xA0:0x00:0x00:0x08:0x20:0x00:0x01'
     packageName = 'im.status.keycard'
     applet {
-      aid = '0xA0:0x00:0x00:0x08:0x04:0x00:0x01:0x01'
+      aid = '0xA0:0x00:0x00:0x08:0x20:0x00:0x01:0x01'
       className = 'KeycardApplet'
     }
     applet {
-      aid = '0xA0:0x00:0x00:0x08:0x04:0x00:0x01:0x02'
+      aid = '0xA0:0x00:0x00:0x08:0x20:0x00:0x01:0x02'
       className = 'NDEFApplet'
     }
     
-    version = '2.2'
+    version = '0.6'
   }
 }
 
@@ -51,10 +51,10 @@ repositories {
 }
 
 dependencies {
-  testCompile(files("../jcardsim/jcardsim-3.0.5-SNAPSHOT.jar"))
+  testCompile(files("../jcardsim/jcardsim-3.0.4-SNAPSHOT.jar"))
   testCompile('org.web3j:core:2.3.1')
   testCompile('org.bitcoinj:bitcoinj-core:0.14.5')
-  testCompile('com.github.status-im.status-keycard-java:desktop:2.2.1')
+  testCompile('com.github.gridplus.safe-card-java-sdk:desktop:3ae2324b08c041be30886b9fc2e1b04c2573d750')
   testCompile('org.bouncycastle:bcprov-jdk15on:1.60')
   testCompile("org.junit.jupiter:junit-jupiter-api:5.1.1")
   testRuntime("org.junit.jupiter:junit-jupiter-engine:5.1.1")

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -4,5 +4,5 @@ repositories {
 }
 
 dependencies {
-  compile 'com.github.status-im.status-keycard-java:desktop:2.2.1'
+  compile 'com.github.gridplus.safe-card-java-sdk:desktop:3ae2324b08c041be30886b9fc2e1b04c2573d750'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -34,7 +34,7 @@ public class KeycardApplet extends Applet {
   static final byte PIN_LENGTH = 6;
   static final byte PIN_MAX_RETRIES = 3;
   static final byte KEY_PATH_MAX_DEPTH = 10;
-  static final byte PAIRING_MAX_CLIENT_COUNT = 5;
+  static final byte PAIRING_MAX_CLIENT_COUNT = 1;
   static final byte UID_LENGTH = 16;
 
   static final short CHAIN_CODE_SIZE = 32;

--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -251,10 +251,13 @@ public class KeycardApplet extends Applet {
       selectApplet(apdu);
       return;
     }
-
+    
     apdu.setIncomingAndReceive();
     try {
       switch (apduBuffer[ISO7816.OFFSET_INS]) {
+        case SecureChannel.INS_IDENTIFY_CARD:
+          secureChannel.identifyCard(apdu);
+          break;
         case SecureChannel.INS_LOAD_CERT:
           secureChannel.loadCert(apdu);
           break;

--- a/src/main/java/im/status/keycard/SecureChannel.java
+++ b/src/main/java/im/status/keycard/SecureChannel.java
@@ -215,18 +215,7 @@ public class SecureChannel {
    * @return the length of the reply
    */
   private short pairStep1(byte[] apduBuffer) {
-    preassignedPairingOffset = -1;
-
-    for (short i = 0; i < (short) pairingKeys.length; i += PAIRING_KEY_LENGTH) {
-      if (pairingKeys[i] == 0) {
-        preassignedPairingOffset = i;
-        break;
-      }
-    }
-
-    if (preassignedPairingOffset == -1) {
-      ISOException.throwIt(ISO7816.SW_FILE_FULL);
-    }
+    preassignedPairingOffset = 0; // Always override pairing slot 0
 
     crypto.sha256.update(pairingSecret, (short) 0, SC_SECRET_LENGTH);
     crypto.sha256.doFinal(apduBuffer, ISO7816.OFFSET_CDATA, SC_SECRET_LENGTH, apduBuffer, (short) 0);

--- a/src/test/java/im/status/keycard/KeycardTest.java
+++ b/src/test/java/im/status/keycard/KeycardTest.java
@@ -354,15 +354,15 @@ public class KeycardTest {
     assertTrue((0x6985 == response.getSw()) || (0x6982 == response.getSw()));
     cmdSet.openSecureChannel(secureChannel.getPairingIndex(), secureChannel.getPublicKey());
 
-    // Pair multiple indexes
-    for (int i = 1; i < 5; i++) {
+    // Fill max pairings
+    for (int i = 1; i < KeycardApplet.PAIRING_MAX_CLIENT_COUNT; i++) {
       cmdSet.autoPair(sharedSecret);
       assertEquals(i, secureChannel.getPairingIndex());
       cmdSet.autoOpenSecureChannel();
       cmdSet.openSecureChannel(secureChannel.getPairingIndex(), secureChannel.getPublicKey());
     }
 
-    // Too many paired indexes
+    // Too many paired clients
     response = cmdSet.pair(SecureChannel.PAIR_P1_FIRST_STEP, challenge);
     assertEquals(0x6A84, response.getSw());
 


### PR DESCRIPTION
Refactor pairing process to allow certificate based pairing.

Functional tests pass for the following commands:
- [x] `identifyCard()`
- [x] `loadCert()`
- [x] `init()`
- [x] `pairStep1()`
- [x] `pairStep2()`

Other commands have not been tested, but they were not modified in this PR