### PR TITLE
Add functionality for storing data

### DIFF
--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -38,7 +38,7 @@ public class KeycardApplet extends Applet {
   static final byte KEY_PATH_MAX_DEPTH = 10;
   static final byte PAIRING_MAX_CLIENT_COUNT = 1;
   static final byte UID_LENGTH = 16;
-  static final byte SAVED_DATA_SIZE = 155; // 5x compressed public key
+  static final byte SAVED_DATA_SIZE = 255 - SecureChannel.SC_OUT_OFFSET; // Max APDU size less the SC overhead
 
   static final short CHAIN_CODE_SIZE = 32;
   static final short KEY_UID_LENGTH = 32;


### PR DESCRIPTION
This PR includes functionality to store and export a chunk of data (155 bytes), which is separated from the rest of the applet. This gives us a bit of future proofing, allowing us to support Shamir splitting and multisig operations in the future. Both APDUs are PIN protected and use secure channels.

The data is 155 bytes because that allows us to store up to 5 compressed public keys (33 bytes each) for a Bitcoin multisig. I believe this is sufficient splitting for most purposes and allows us to add more data-intensive features to v2+ cards (e.g. Phonon) while maintaining backward compatibility.